### PR TITLE
feat/css style to avoid code word break in tables

### DIFF
--- a/.changeset/tender-flowers-collect.md
+++ b/.changeset/tender-flowers-collect.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs': minor
 ---
 
-code tag css style changed to avoid word break
+Updated the styling for <code> tags to avoid word break.

--- a/.changeset/tender-flowers-collect.md
+++ b/.changeset/tender-flowers-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+code tag css style changed to avoid word break

--- a/plugins/techdocs/src/reader/transformers/styles/rules/typeset.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/typeset.ts
@@ -115,4 +115,8 @@ ${headings.reduce<string>((style, heading) => {
 .md-typeset pre > code::-webkit-scrollbar-thumb:hover {
   background-color: hsla(0, 0%, 0%, 0.87);
 }
+
+.md-typeset code {
+  word-break: keep-all;
+}
 `;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Code CSS style changed to avoid code word break.

Currently the code in tables looks like this:

![image](https://github.com/luis-k0/backstage-fork/assets/44954252/f4b77f48-53c9-4a5e-9378-1643612ccc62)

With the change it will look like this:

![image](https://github.com/luis-k0/backstage-fork/assets/44954252/e74fe5ef-defc-4c43-921a-3edefc844c69)

A scrollbar will be included if the table does not fit in width.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
